### PR TITLE
Passes along bountyType to bounty as type.

### DIFF
--- a/__tests__/getTokenValues.test.js
+++ b/__tests__/getTokenValues.test.js
@@ -4,12 +4,16 @@ describe('getTokenValues', () => {
 	it('getTokenValues', async () => {
 		const mockOrganizationId = "organizationId";
 		const mockBountyAddress = "bountyAddress";
+		const mockBountyType = "1"
 		const wbtcAddress = "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6";
+		const mockBountyId = "I_kwDOHAZTVc5PYxa5"
 		const bounty = {
 			bountyAddress: mockBountyAddress,
 			organization: {
 				id: mockOrganizationId
 			},
+			bountyId: "I_kwDOHAZTVc5PYxa5",
+			bountyType: "1",
 			bountyTokenBalances: [
 				{ tokenAddress: wbtcAddress, volume: 1000 },
 				{ tokenAddress: wbtcAddress, volume: 1000 },
@@ -30,11 +34,15 @@ describe('getTokenValues', () => {
 		const expectedTvlBody = [{
 			address: mockBountyAddress,
 			tvl: expectedTvl,
-			organizationId: mockOrganizationId
+			organizationId: mockOrganizationId,
+			type: mockBountyType,
+			bountyId: mockBountyId
 		},
 		{
 			address: mockBountyAddress,
 			tvl: expectedTvl,
+			type: mockBountyType,
+			bountyId: mockBountyId,
 			organizationId: mockOrganizationId
 		}
 		];

--- a/src/getTokenValues.js
+++ b/src/getTokenValues.js
@@ -18,6 +18,7 @@ const getTokenValues = async (bounties, pricingMetadata, data, environment) => {
 		return {
 			address: bounty.bountyAddress,
 			bountyId: bounty.bountyId,
+			type: bounty.bountyType,
 			tvl,
 			organizationId: bounty.organization.id,
 		};

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -14,6 +14,7 @@ const GET_ALL_BOUNTIES = `
 		bounties(skip: $skip, sortOrder: $sortOrder, quantity: $quantity) {
 			bountyAddress
 			bountyId
+			bountyType
 			organization {
 				id
 			}
@@ -31,9 +32,11 @@ const UPDATE_BOUNTY_TVL = `
 		$tvl: Float!
 		$organizationId: String!
 		$bountyId: String!
+		$type: String!
 	) {
 		updateBounty(
 			address: $address
+			type: $type
 			tvl: $tvl
 			organizationId: $organizationId
 			bountyId: $bountyId

--- a/src/updateTvls.js
+++ b/src/updateTvls.js
@@ -10,6 +10,7 @@ const updateTvls = async (tvlBodies) => {
 		const address = getAddress(value.address);
 		const tvl = parseFloat(value.tvl);
 		const bountyId = value.bountyId;
+		const type = value.type
 		const { organizationId } = value;
 
 		let result = null;
@@ -19,7 +20,7 @@ const updateTvls = async (tvlBodies) => {
 					`${process.env.OPENQ_API_URL}/graphql`,
 					{
 						query: UPDATE_BOUNTY_TVL,
-						variables: { address, tvl, organizationId, bountyId },
+						variables: { address, tvl, organizationId, bountyId, type },
 					},
 					{
 						headers: {


### PR DESCRIPTION
Requires [https://github.com/OpenQDev/OpenQ-API/pull/16](https://github.com/OpenQDev/OpenQ-API/pull/16)
Now passes along the bountyType from the graph to the bounty being upserted via the api.
We should be able to remove this functionality once the bounty actions autotask is updated.