### PR TITLE
Set contests label to singular

### DIFF
--- a/src/getContractParameters.js
+++ b/src/getContractParameters.js
@@ -25,7 +25,7 @@ const getContractParameters = async (bounties, pricingMetadata, data, environmen
 		if (type === "1" && labels?.some(label=>label === "learn2earn") ) {
 			return "learn2earn";
 		}
-		if ((type === "2" || type === "3") && labels?.some(label=>label === "contests")) {
+		if ((type === "2" || type === "3") && labels?.some(label=>label === "contest")) {
 			return "contest";
 			}
 		return undefined		


### PR DESCRIPTION
Now categorizes bounties as contests only if they have the label "contest" (case indifferent)